### PR TITLE
Add a cache prefix for multitenancy

### DIFF
--- a/lib/liquex/context.ex
+++ b/lib/liquex/context.ex
@@ -60,6 +60,7 @@ defmodule Liquex.Context do
             file_system: nil,
             errors: [],
             cache: nil
+            cache_prefix: nil
 
   @type t :: %__MODULE__{
           environment: map(),
@@ -70,6 +71,7 @@ defmodule Liquex.Context do
           filter_module: module,
           file_system: struct,
           cache: term,
+          cache_prefix: String.t(),
           errors: list(Liquex.Error.t())
         }
 
@@ -92,6 +94,9 @@ defmodule Liquex.Context do
     * :filter_module - Module that will be used for filtering
 
     * :file_system - File loading module
+
+    * :cache_prefix - Prefix for cache keys, if you need separate partial caches
+      for multitenancy or otherwise
   """
   @spec new(map(), Keyword.t()) :: t()
   def new(environment, opts \\ []) do
@@ -101,7 +106,8 @@ defmodule Liquex.Context do
       scope: Scope.new(Keyword.get(opts, :scope, %{})),
       filter_module: Keyword.get(opts, :filter_module, Liquex.Filter),
       file_system: Keyword.get(opts, :file_system, %Liquex.BlankFileSystem{}),
-      cache: Keyword.get(opts, :cache, Liquex.Cache.DisabledCache)
+      cache: Keyword.get(opts, :cache, Liquex.Cache.DisabledCache),
+      cache_prefix: Keyword.get(opts, :cache_prefix, nil)
     }
   end
 

--- a/lib/liquex/tag/render_tag.ex
+++ b/lib/liquex/tag/render_tag.ex
@@ -212,8 +212,12 @@ defmodule Liquex.Tag.RenderTag do
   end
 
   @spec load_contents({:literal, String.t()}, Context.t()) :: Liquex.document_t() | no_return()
-  defp load_contents({:literal, template_name}, %Context{file_system: file_system, cache: cache}) do
-    cache.fetch("Liquex.Tag.RenderTag:partial." <> template_name, fn ->
+  defp load_contents({:literal, template_name}, %Context{
+         file_system: file_system,
+         cache: cache,
+         cache_prefix: cache_prefix
+       }) do
+    cache.fetch("#{cache_prefix}:Liquex.Tag.RenderTag:partial." <> template_name, fn ->
       file_system
       |> FileSystem.read_template_file(template_name)
       |> Liquex.parse!()


### PR DESCRIPTION
If we have sets of partials that are different per client/scope/etc, we want to be able to cache these partials separately from each other, even when using the same global cache itself. I've added `cache_prefix` to satisfy this.